### PR TITLE
Make Rails 4.1 compatible and update minor versions

### DIFF
--- a/table_cloth.gemspec
+++ b/table_cloth.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('factory_girl')
   gem.add_development_dependency('guard-rspec')
   gem.add_development_dependency('rake')
-  gem.add_development_dependency('rb-fsevent', '~> 0.9.1')
+  gem.add_development_dependency('rb-fsevent', '~> 0.9.4')
 
-  gem.add_dependency('actionpack', '>= 3.1', '< 4.1')
-  gem.add_dependency('element_factory', '~> 0.1.0')
+  gem.add_dependency('actionpack', '>= 3.1', '< 4.2')
+  gem.add_dependency('element_factory', '~> 0.1.2')
 end


### PR DESCRIPTION
Hi, Rails 4.1 was released yesterday. I updated the gemspec, tests are still passing.

I also made a similar pull request to element_factory https://github.com/bobbytables/element_factory/pull/2

My `bundle install` does not fail anymore. (Using my git repo as gem source)
Please update the rubygem too, thanks!
