### PR TITLE
Fixes to_s method not returning a string.

### DIFF
--- a/lib/table_cloth/presenters/default.rb
+++ b/lib/table_cloth/presenters/default.rb
@@ -5,7 +5,7 @@ module TableCloth
         @render_table ||= ElementFactory::Element.new(:table, tag_options(:table)).tap do |table|
           table << thead
           table << tbody
-        end
+        end.to_html
       end
 
       def thead


### PR DESCRIPTION
This problem arose in #rubyonrails where someone reported that your `simple_table_for` helper output HTML was being escaped using the Slim templating engine, but was rendering fine in ERB.

After a bit of digging, the essence of the problem is that ERB calls `.to_s` before calling `.html_safe?` to determine whether to escape the HTML or not. Table Cloth actually returns a ElementFactory::Element from the helper, which has a `.to_s` method that returns a html_safe string, so all's good in ERB. However [Slim calls `.html_safe?` on the ElementFactory::Element itself](https://github.com/slim-template/slim/issues/490), which returns false.

There's a number of potential solutions to this, for instance adding `def html_safe?() true end` to ElementFactory::Element, but I think the most correct resolution is to fix the [to_s method](https://github.com/bobbytables/table_cloth/blob/master/lib/table_cloth/builder.rb#L22-L24) on TableCloth::Builder (called [here](https://github.com/bobbytables/table_cloth/blob/master/lib/table_cloth/action_view_extension.rb#L13)) so that it actually returns a String. It's a bit disingenuous to not return a string from to_s.

That method calls `render_table` on the Presenter, which is where we return the ElementFactory::Element. I believe this would be the best place to convert to a string because "render" suggests that it should return a string, to me.
