### PR TITLE
Add row_attributes

### DIFF
--- a/lib/table_cloth.rb
+++ b/lib/table_cloth.rb
@@ -19,6 +19,7 @@ module TableCloth
 
   module Extensions
     autoload :Actions, "table_cloth/extensions/actions"
+    autoload :RowAttributes, "table_cloth/extensions/row_attributes"
   end
 
   class << self

--- a/lib/table_cloth/base.rb
+++ b/lib/table_cloth/base.rb
@@ -1,6 +1,7 @@
 module TableCloth
   class Base
     include TableCloth::Extensions::Actions
+    include TableCloth::Extensions::RowAttributes
 
     NoPresenterError = Class.new(Exception)
 
@@ -58,21 +59,6 @@ module TableCloth
         else
           Configuration.new
         end
-      end
-
-      def row_attributes(*args, &block)
-        @tr_options ||= {}
-        options = args.extract_options! || {}
-        options[:proc] = block if block_given?
-        @tr_options = options
-      end
-
-      def tr_options
-        @tr_options ||= {}
-        if superclass.respond_to? :tr_options
-          @tr_options = superclass.tr_options.merge(@tr_options)
-        end
-        @tr_options
       end
     end
   end

--- a/lib/table_cloth/extensions/row_attributes.rb
+++ b/lib/table_cloth/extensions/row_attributes.rb
@@ -1,0 +1,36 @@
+module TableCloth
+  module Extensions
+    module RowAttributes
+
+      extend ActiveSupport::Concern
+
+      module ClassMethods
+
+        def row_attributes(*args, &block)
+          @tr_options ||= {}
+          options = args.extract_options! || {}
+          options[:proc] = block if block_given?
+          @tr_options = options
+        end
+
+        def tr_options
+          @tr_options ||= {}
+          if superclass.respond_to? :tr_options
+            @tr_options = superclass.tr_options.merge(@tr_options)
+          end
+          @tr_options
+        end
+
+        def tr_options_for(object)
+          options = tr_options
+          if options.include?(:proc)
+            result = options[:proc].call(object) || {}
+            options.except(:proc).merge(result)
+          else
+            options
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/table_cloth/presenters/default.rb
+++ b/lib/table_cloth/presenters/default.rb
@@ -33,7 +33,9 @@ module TableCloth
       end
 
       def row_for_object(object)
-        ElementFactory::Element.new(:tr, tag_options(:tr).merge(tr_options(object))).tap do |row|
+        tr_options = table.class.tr_options_for(object)
+
+        ElementFactory::Element.new(:tr, tag_options(:tr).merge(tr_options)).tap do |row|
           columns.each do |column|
             row << column_for_object(column, object)
           end
@@ -58,15 +60,6 @@ module TableCloth
         end
 
         ElementFactory::Element.new(:td, tag_options(:td).merge(td_options))
-      end
-
-      def tr_options(object)
-        options = table.class.tr_options.clone
-        if (block = options.delete(:proc))
-          results = block.call(object) || {}
-          options.merge!(results)
-        end
-        options
       end
     end
   end

--- a/spec/lib/presenters/default_spec.rb
+++ b/spec/lib/presenters/default_spec.rb
@@ -51,6 +51,12 @@ describe TableCloth::Presenters::Default do
       expect(tbody.css('tr').size).to be 3
     end
 
+    it "creates a row with attributes from row_attributes" do
+      tbody = Nokogiri::HTML(subject.tbody.to_s)
+      expect(tbody.css('tr:first-child').first.attribute("class").value).to eq("quazimodo-is-awesome")
+      expect(tbody.css('tr:first-child').first.attribute("name").value).to eq("What a handsome quazimodo")
+    end
+
     context 'escaped values' do
       let(:objects) do
         FactoryGirl.build_list(:dummy_model, 1,

--- a/spec/support/dummy_table.rb
+++ b/spec/support/dummy_table.rb
@@ -1,4 +1,7 @@
 class DummyTable < TableCloth::Base
+  row_attributes name: "What a handsome quazimodo" do |obj|
+    {class: "quazimodo-is-awesome"} if obj.present?
+  end
   column :id, th_options: {class: "th_options_class"}
   column :name
   column :email
@@ -7,5 +10,5 @@ end
 class DummyTableUnlessAdmin < TableCloth::Base
   column :id, unless: :admin?
   column :name
-  column :email  
+  column :email
 end


### PR DESCRIPTION
Add ability to specify options/attributes on rows via args or block, eg:

``` ruby
class SomeTable < DefaultTable

  row_attributes do |obj|
    {class: "danger"} if obj.is_dangerous?
  end

  column :whatever

end
```

or

``` ruby
class SomeTable < DefaultTable

  row_attributes class: "danger"

  column :whatever

end
```
