### PR TITLE
Modified treatment of conditionals in actions

### DIFF
--- a/lib/table_cloth/extensions/actions/action.rb
+++ b/lib/table_cloth/extensions/actions/action.rb
@@ -10,8 +10,8 @@ module TableCloth::Extensions::Actions
       @jury ||= Jury.new(self)
     end
 
-    def value(object, view)
-      if jury.available?(object)
+    def value(object, view, table)
+      if jury.available?(object, table)
         view.instance_exec(object, &options[:proc])
       else
         ""

--- a/lib/table_cloth/extensions/actions/column.rb
+++ b/lib/table_cloth/extensions/actions/column.rb
@@ -2,7 +2,7 @@ module TableCloth::Extensions::Actions
   class Column < ::TableCloth::Column
     def value(object, view, table=nil)
       actions = action_collection.actions.map do |action|
-        action.value(object, view)
+        action.value(object, view, table)
       end
 
       view.raw(actions.join(separator))

--- a/lib/table_cloth/extensions/actions/jury.rb
+++ b/lib/table_cloth/extensions/actions/jury.rb
@@ -6,19 +6,19 @@ module TableCloth::Extensions::Actions
       @action = action
     end
 
-    def available?(object)
+    def available?(object, table)
       case action_if
       when Proc
         return !!action_if.call(object)
       when Symbol
-        return !!object.send(action_if)
+        return !!table.send(action_if)
       end
 
       case action_unless
       when Proc
         return !action_unless.call(object)
       when Symbol
-        return !object.send(action_unless)
+        return !table.send(action_unless)
       end
 
       return true

--- a/spec/lib/extensions/actions/action_spec.rb
+++ b/spec/lib/extensions/actions/action_spec.rb
@@ -15,12 +15,13 @@ describe TableCloth::Extensions::Actions::Action do
   context "#value" do
     let(:model) { FactoryGirl.build(:dummy_model) }
     let(:view_context) { ActionView::Base.new }
+    let(:table) { TableCloth::Base.new(nil, nil) }
 
     context "string" do
       let(:action_hash) { {proc: Proc.new{ "something" }} }
 
       it "returns a string" do
-        expect(subject.value(model, view_context)).to match /something/
+        expect(subject.value(model, view_context, table)).to match /something/
       end
     end
 
@@ -30,8 +31,8 @@ describe TableCloth::Extensions::Actions::Action do
       end
 
       it "returns a link" do
-        expect(subject.value(model, view_context)).to match /href="something"/
-        expect(subject.value(model, view_context)).to match />blank</
+        expect(subject.value(model, view_context, table)).to match /href="something"/
+        expect(subject.value(model, view_context, table)).to match />blank</
       end
     end
 
@@ -45,12 +46,12 @@ describe TableCloth::Extensions::Actions::Action do
 
       it "returns the link when the model condition succeeds" do
         model.stub admin?: true
-        expect(subject.value(model, view_context)).to include "something"
+        expect(subject.value(model, view_context, table)).to include "something"
       end
 
       it "does not return the link when the model condition fails" do
         model.stub admin?: false
-        expect(subject.value(model, view_context)).not_to include "something"
+        expect(subject.value(model, view_context, table)).not_to include "something"
       end
     end
   end

--- a/spec/lib/extensions/actions/jury_spec.rb
+++ b/spec/lib/extensions/actions/jury_spec.rb
@@ -4,6 +4,7 @@ describe TableCloth::Extensions::Actions::Jury do
   let(:action) { FactoryGirl.build(:action, options: action_options) }
   subject { described_class.new(action) }
   let(:model) { double("model") }
+  let(:table) { TableCloth::Base.new(nil, nil) }
 
   context "Proc" do
     context "if .available?" do
@@ -11,12 +12,12 @@ describe TableCloth::Extensions::Actions::Jury do
 
       it "returns true for valid models" do
         model.stub state: "valid"
-        expect(subject).to be_available(model)
+        expect(subject).to be_available(model, table)
       end
 
       it "returns false for invalid models" do
         model.stub state: "invalid"
-        expect(subject).not_to be_available(model)
+        expect(subject).not_to be_available(model, table)
       end
     end
 
@@ -25,12 +26,12 @@ describe TableCloth::Extensions::Actions::Jury do
       
       it "returns true for valid models" do
         model.stub state: "valid"
-        expect(subject).to be_available(model)
+        expect(subject).to be_available(model, table)
       end
 
       it "returns false for invalid models" do
         model.stub state: "invalid"
-        expect(subject).not_to be_available(model)
+        expect(subject).not_to be_available(model, table)
       end
     end
   end
@@ -40,13 +41,13 @@ describe TableCloth::Extensions::Actions::Jury do
       let(:action_options) { {if: :valid?} }
 
       it "returns true for valid?" do
-        model.stub valid?: true
-        expect(subject).to be_available(model)
+        table.stub valid?: true
+        expect(subject).to be_available(model, table)
       end
 
       it "returns true for valid?" do
-        model.stub valid?: false
-        expect(subject).not_to be_available(model)
+        table.stub valid?: false
+        expect(subject).not_to be_available(model, table)
       end
     end
 
@@ -54,13 +55,13 @@ describe TableCloth::Extensions::Actions::Jury do
       let(:action_options) { {unless: :valid?} }
       
       it "returns true for valid models" do
-        model.stub valid?: false
-        expect(subject).to be_available(model)
+        table.stub valid?: false
+        expect(subject).to be_available(model, table)
       end
 
       it "returns false for invalid models" do
-        model.stub valid?: true
-        expect(subject).not_to be_available(model)
+        table.stub valid?: true
+        expect(subject).not_to be_available(model, table)
       end
     end
   end


### PR DESCRIPTION
This pull request is a proposed fix for issue #39. 
When a condition for an action is provided  as a symbol, the corresponding method is called on the table:

``` ruby
class EventTable < TableCloth::Base
  column :name

  actions do
    action(if: :admin?) {|object| link_to 'Delete', object, method: :delete }
  end

  def admin?
    view.current_user.admin?
  end
end
```

When a condition is provided as a proc or lambda, both the object and the table are passed in:

``` ruby
class EventTable < TableCloth::Base
  column :name

  actions do
    action(if: ->(object, table) { !object.read_only? }) {|object| link_to 'Delete', object, method: :delete }
  end
end
```

I'm not sure whether this is the right choice for procs. As stated in #39, it is easy to add object dependent conditions inside the action block itself.

Please note that while this pull request makes the code consistent with the README, it might break existing applications that rely on the old behaviour.
