### PR TITLE
Support Rails 4.2, bump rspec version and fix specs

### DIFF
--- a/spec/lib/base_spec.rb
+++ b/spec/lib/base_spec.rb
@@ -39,7 +39,7 @@ describe TableCloth::Base do
     end
 
     context "custom" do
-      let(:custom_column) { stub(:custom, value: "AN EMAIL") }
+      let(:custom_column) { double(:custom, value: "AN EMAIL") }
 
       it '.column can take a custom column' do
         subject.column :email, using: custom_column

--- a/spec/lib/column_jury_spec.rb
+++ b/spec/lib/column_jury_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe TableCloth::ColumnJury do
-  let(:dummy_table) { stub(:table, admin?: true, moderator?: false) }
+  let(:dummy_table) { double(:table, admin?: true, moderator?: false) }
 
   subject { TableCloth::ColumnJury.new(column, dummy_table) }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'nokogiri'
 require 'factory_girl'
 require 'pry'
 require 'simplecov'
+require 'rspec/collection_matchers'
 
 if ENV["COVERAGE"] == "true"
   SimpleCov.start do

--- a/table_cloth.gemspec
+++ b/table_cloth.gemspec
@@ -17,7 +17,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency('rspec', '~> 2.11')
+  gem.add_development_dependency('rspec', '~> 2.99.0')
+  gem.add_development_dependency('rspec-collection_matchers')
   gem.add_development_dependency('simplecov')
   gem.add_development_dependency('awesome_print')
   gem.add_development_dependency('nokogiri')
@@ -27,6 +28,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rake')
   gem.add_development_dependency('rb-fsevent', '~> 0.9.4')
 
-  gem.add_dependency('actionpack', '>= 3.1', '< 4.2')
-  gem.add_dependency('element_factory', '~> 0.1.2')
+  gem.add_dependency('actionpack', '>= 3.1', '< 5.0')
+  gem.add_dependency('element_factory', '~> 0.1.3')
 end


### PR DESCRIPTION
Hi, I bumped the Rails dependency (because Rails master is now working on 5.0, `< 5.0` should be safe) to use it with Rails 4.2 and upcoming minor releases. I also bumped the rspec minor version and fixed some deprecation warnings (replaced `stub` with `double` and added the `rspec-collection_matchers` gem).

Merry Christmas!
