### PR TITLE
Pass view_context along to row_attributes proc

### DIFF
--- a/lib/table_cloth/extensions/row_attributes.rb
+++ b/lib/table_cloth/extensions/row_attributes.rb
@@ -21,10 +21,10 @@ module TableCloth
           @tr_options
         end
 
-        def tr_options_for(object)
+        def tr_options_for(object, view_context)
           options = tr_options
           if options.include?(:proc)
-            result = options[:proc].call(object) || {}
+            result = options[:proc].call(object, view_context) || {}
             options.except(:proc).merge(result)
           else
             options

--- a/lib/table_cloth/presenters/default.rb
+++ b/lib/table_cloth/presenters/default.rb
@@ -16,7 +16,7 @@ module TableCloth
 
       def tbody
         @tbody ||= ElementFactory::Element.new(:tbody, tag_options(:tbody)).tap do |tbody|
-          objects.each {|object| tbody << row_for_object(object) }
+          objects.each {|object| tbody << row_for_object(object, view_context) }
         end
       end
 
@@ -32,8 +32,8 @@ module TableCloth
         end
       end
 
-      def row_for_object(object)
-        tr_options = table.class.tr_options_for(object)
+      def row_for_object(object, view_context)
+        tr_options = table.class.tr_options_for(object, view_context)
 
         ElementFactory::Element.new(:tr, tag_options(:tr).merge(tr_options)).tap do |row|
           columns.each do |column|


### PR DESCRIPTION
We've forked this for our own needs for now, and not sure if this is something you'd want pulled into your repo, but we had the use case something like the following:

```
row_attributes do |object, view_context|
  css_class = object.owned_by?(view_context.current_user) ? 'accepted' : ''
  { class: css_class }
end
```
